### PR TITLE
Establishment additional properties

### DIFF
--- a/test/accounts/accounts.test.js
+++ b/test/accounts/accounts.test.js
@@ -1203,6 +1203,8 @@ describe ("Change User Details", async () => {
 
     // update all properties before checking the timeline history
     it('should get user with timeline history', async () => {
+        expect(knownUserUid).not.toBeNull();
+        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
 
         // force a login failure (to expect on event)
@@ -1259,6 +1261,8 @@ describe ("Change User Details", async () => {
         expect(allUpdatedEvents.length).toEqual(18); // six properties to have been updated (three times)
         allUpdatedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
+            expect(thisEvent.change).toBeNull();
+            expect(thisEvent.property).toBeNull();
             expect(thisEvent.when).toEqual(new Date(thisEvent.when).toISOString());
         });
 
@@ -1270,8 +1274,10 @@ describe ("Change User Details", async () => {
         expect(allChangedEvents.length).toEqual(12); // six properties to have been updated twice
         allChangedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
+            expect(thisEvent.change).not.toBeNull();
             expect(thisEvent.change).toHaveProperty('new');
             expect(thisEvent.change).toHaveProperty('current');
+            expect(thisEvent.property).not.toBeNull();
             expect(thisEvent.when).toEqual(new Date(thisEvent.when).toISOString());
         });
 
@@ -1283,12 +1289,17 @@ describe ("Change User Details", async () => {
         expect(allSavedEvents.length).toEqual(18); // six properties to have been saved three times (twice with change and once without change)
         allSavedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
+            expect(thisEvent.change).toBeNull();
+            expect(thisEvent.property).not.toBeNull();
             expect(thisEvent.when).toEqual(new Date(thisEvent.when).toISOString());
         });
     });
 
     it('should get user with full history', async () => {
+        expect(knownUserUid).not.toBeNull();
+        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
+        expect(establishmentId).not.toBeNull();
 
         // force a login failure (to expect on event)
         await apiEndpoint.post('/login')

--- a/test/accounts/accounts.test.js
+++ b/test/accounts/accounts.test.js
@@ -59,7 +59,6 @@ describe("Password Resets", async () => {
             .expect('Content-Type', /json/)
             .expect(200);
         expect(loginResponse.body.role).toEqual('Edit');
-    
     });
 
     it("should lookup a known username via usernameOrPasswword with success", async () => {
@@ -187,7 +186,6 @@ describe("Password Resets", async () => {
         successfullToken = validateResponse.headers.authorization;
     });
     it("should not fail on completed token when re-validating password reset", async () => {
-        expect(successfulUuid).not.toBeNull();
 
         await apiEndpoint.post('/registration/validateResetPassword')
             .send({
@@ -241,7 +239,6 @@ describe("Password Resets", async () => {
 
     let successfulLoginToken = null;
     it("should success on reset password if using a valid token and valid password", async () => {
-        expect(successfulUuid).not.toBeNull();
 
         await apiEndpoint.post('/user/resetPassword')
             .set('Authorization', successfullToken)
@@ -287,7 +284,6 @@ describe("Password Resets", async () => {
             .expect(401);
     });
     it("should fail for change password with 403 if no authorisation header is not a valid logged in JWT", async () => {
-        expect(successfulUuid).not.toBeNull();
 
         await apiEndpoint.post('/user/changePassword')
             .set('Authorization', successfullToken)
@@ -300,7 +296,6 @@ describe("Password Resets", async () => {
     });
 
     it("should fail for change password with 400 current/new password is not given", async () => {
-        expect(successfulLoginToken).not.toBeNull();
 
         await apiEndpoint.post('/user/changePassword')
             .set('Authorization', successfulLoginToken)
@@ -322,7 +317,6 @@ describe("Password Resets", async () => {
     });
 
     it("should fail for change password with 400 new password is not of required complexity", async () => {
-        expect(successfulLoginToken).not.toBeNull();
 
         // NOTE - there is no checking on history of password used
         // Intentionally not validating complexity of current password
@@ -338,7 +332,6 @@ describe("Password Resets", async () => {
 
 
     it("should fail for change password with 403 if header is good, but current password is incorrect", async () => {
-        expect(successfulLoginToken).not.toBeNull();
 
         await apiEndpoint.post('/user/changePassword')
             .set('Authorization', successfulLoginToken)
@@ -453,9 +446,6 @@ describe ("Change User Details", async () => {
     });
 
     it('should return a User by uid no history', async () => {
-        expect(knownUserUid).not.toBeNull();
-        expect(loginAuthToken).not.toBeNull();
-        expect(establishmentId).not.toBeNull();
         
         const getUserResponse = await apiEndpoint.get(`/user/establishment/${establishmentId}/${encodeURIComponent(knownUserUid)}?history=none`)
             .set('Authorization', loginAuthToken)
@@ -495,10 +485,7 @@ describe ("Change User Details", async () => {
     });
 
     it('should return a User by username no history', async () => {
-        expect(knownUserUid).not.toBeNull();
-        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
-        expect(establishmentId).not.toBeNull();
 
         const getUserResponse = await apiEndpoint.get(`/user/establishment/${establishmentId}/${encodeURIComponent(fetchUsername)}?history=none`)
             .set('Authorization', loginAuthToken)
@@ -534,10 +521,7 @@ describe ("Change User Details", async () => {
     });
 
     it('should get user with property history', async () => {
-        expect(knownUserUid).not.toBeNull();
-        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
-        expect(establishmentId).not.toBeNull();
 
         const getUserResponse = await apiEndpoint.get(`/user/establishment/${establishmentId}/${encodeURIComponent(fetchUsername)}?history=property`)
             .set('Authorization', loginAuthToken)
@@ -641,7 +625,8 @@ describe ("Change User Details", async () => {
             requestEpoch,
             (ref, given) => {
                 return ref == given
-            });
+            },
+            6);
         let lastSavedDate = userChangeHistory.body.fullname.lastSaved;
         
         // now update the property but with same value - expect no change
@@ -742,7 +727,8 @@ describe ("Change User Details", async () => {
             requestEpoch,
             (ref, given) => {
                 return ref == given
-            });
+            },
+            6);
         let lastSavedDate = userChangeHistory.body.jobTitle.lastSaved;
         
         // now update the property but with same value - expect no change
@@ -843,7 +829,8 @@ describe ("Change User Details", async () => {
             requestEpoch,
             (ref, given) => {
                 return ref == given
-            });
+            },
+            6);
         let lastSavedDate = userChangeHistory.body.email.lastSaved;
         
         // now update the property but with same value - expect no change
@@ -957,7 +944,8 @@ describe ("Change User Details", async () => {
             requestEpoch,
             (ref, given) => {
                 return ref == given
-            });
+            },
+            6);
         let lastSavedDate = userChangeHistory.body.phone.lastSaved;
         
         // now update the property but with same value - expect no change
@@ -1057,7 +1045,8 @@ describe ("Change User Details", async () => {
             requestEpoch,
             (ref, given) => {
                 return ref == given
-            });
+            },
+            6);
         let lastSavedDate = userChangeHistory.body.securityQuestion.lastSaved;
         
         // now update the property but with same value - expect no change
@@ -1158,7 +1147,8 @@ describe ("Change User Details", async () => {
             requestEpoch,
             (ref, given) => {
                 return ref == given
-            });
+            },
+            6);
         let lastSavedDate = userChangeHistory.body.securityQuestionAnswer.lastSaved;
         
         // now update the property but with same value - expect no change
@@ -1213,13 +1203,10 @@ describe ("Change User Details", async () => {
 
     // update all properties before checking the timeline history
     it('should get user with timeline history', async () => {
-        expect(knownUserUid).not.toBeNull();
-        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
-        expect(establishmentId).not.toBeNull();
 
         // force a login failure (to expect on event)
-        await apiEndpoint.post('/login')
+        const loginResponse = await apiEndpoint.post('/login')
             .send({
                 username: nonCQCSite.user.username,
                 password: 'bob'
@@ -1247,8 +1234,6 @@ describe ("Change User Details", async () => {
         // expect(userCreated.username).toEqual(nonCQCSite.user.username);
         // expect(userCreated.event).toEqual('created');
         // expect(userCreated.when).toEqual(new Date().userCreated.whentoISOString());
-        // expect(userCreated.change).toBeNull();
-        // expect(userCreated.property).toBeNull();
         const loginSuccess = getUserResponse.body.history.find(thisEvent => {
             return thisEvent.event === 'loginSuccess';
         });
@@ -1274,8 +1259,6 @@ describe ("Change User Details", async () => {
         expect(allUpdatedEvents.length).toEqual(18); // six properties to have been updated (three times)
         allUpdatedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
-            expect(thisEvent.change).toBeNull();
-            expect(thisEvent.property).toBeNull();
             expect(thisEvent.when).toEqual(new Date(thisEvent.when).toISOString());
         });
 
@@ -1287,10 +1270,8 @@ describe ("Change User Details", async () => {
         expect(allChangedEvents.length).toEqual(12); // six properties to have been updated twice
         allChangedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
-            expect(thisEvent.change).not.toBeNull();
             expect(thisEvent.change).toHaveProperty('new');
             expect(thisEvent.change).toHaveProperty('current');
-            expect(thisEvent.property).not.toBeNull();
             expect(thisEvent.when).toEqual(new Date(thisEvent.when).toISOString());
         });
 
@@ -1302,17 +1283,12 @@ describe ("Change User Details", async () => {
         expect(allSavedEvents.length).toEqual(18); // six properties to have been saved three times (twice with change and once without change)
         allSavedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
-            expect(thisEvent.change).toBeNull();
-            expect(thisEvent.property).not.toBeNull();
             expect(thisEvent.when).toEqual(new Date(thisEvent.when).toISOString());
         });
     });
 
     it('should get user with full history', async () => {
-        expect(knownUserUid).not.toBeNull();
-        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
-        expect(establishmentId).not.toBeNull();
 
         // force a login failure (to expect on event)
         await apiEndpoint.post('/login')
@@ -1343,8 +1319,6 @@ describe ("Change User Details", async () => {
         // expect(userCreated.username).toEqual(nonCQCSite.user.username);
         // expect(userCreated.event).toEqual('created');
         // expect(userCreated.when).toEqual(new Date().userCreated.whentoISOString());
-        // expect(userCreated.change).toBeNull();
-        // expect(userCreated.property).toBeNull();
         const loginSuccess = getUserResponse.body.history.find(thisEvent => {
             return thisEvent.event === 'loginSuccess';
         });

--- a/test/accounts/accounts.test.js
+++ b/test/accounts/accounts.test.js
@@ -1287,7 +1287,7 @@ describe ("Change User Details", async () => {
             return thisEvent.event == 'changed';
         });
         // console.log("TEST DEBUG: Number of changed events: ", allChangedEvents.length);
-        expect(allChangedEvents.length).toEqual(12); // six properties to have been updated twice
+        expect(allChangedEvents.length).toEqual(19); // six properties to have been updated twice
         allChangedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
             expect(thisEvent.change).not.toBeNull();
@@ -1302,7 +1302,7 @@ describe ("Change User Details", async () => {
             return thisEvent.event == 'saved';
         });
         // console.log("TEST DEBUG: Number of saved events: ", allSavedEvents.length);
-        expect(allSavedEvents.length).toEqual(18); // six properties to have been saved three times (twice with change and once without change)
+        expect(allSavedEvents.length).toEqual(25); // six properties to have been saved three times (twice with change and once without change)
         allSavedEvents.forEach(thisEvent => {
             expect(thisEvent.username).toEqual(nonCQCSite.user.username);
             expect(thisEvent.change).toBeNull();

--- a/test/accounts/accounts.test.js
+++ b/test/accounts/accounts.test.js
@@ -186,6 +186,7 @@ describe("Password Resets", async () => {
         successfullToken = validateResponse.headers.authorization;
     });
     it("should not fail on completed token when re-validating password reset", async () => {
+        expect(successfulUuid).not.toBeNull();
 
         await apiEndpoint.post('/registration/validateResetPassword')
             .send({
@@ -239,6 +240,7 @@ describe("Password Resets", async () => {
 
     let successfulLoginToken = null;
     it("should success on reset password if using a valid token and valid password", async () => {
+        expect(successfulUuid).not.toBeNull();
 
         await apiEndpoint.post('/user/resetPassword')
             .set('Authorization', successfullToken)
@@ -284,6 +286,7 @@ describe("Password Resets", async () => {
             .expect(401);
     });
     it("should fail for change password with 403 if no authorisation header is not a valid logged in JWT", async () => {
+        expect(successfulUuid).not.toBeNull();
 
         await apiEndpoint.post('/user/changePassword')
             .set('Authorization', successfullToken)
@@ -296,6 +299,7 @@ describe("Password Resets", async () => {
     });
 
     it("should fail for change password with 400 current/new password is not given", async () => {
+        expect(successfulLoginToken).not.toBeNull();
 
         await apiEndpoint.post('/user/changePassword')
             .set('Authorization', successfulLoginToken)
@@ -317,6 +321,7 @@ describe("Password Resets", async () => {
     });
 
     it("should fail for change password with 400 new password is not of required complexity", async () => {
+        expect(successfulLoginToken).not.toBeNull(); 
 
         // NOTE - there is no checking on history of password used
         // Intentionally not validating complexity of current password
@@ -332,6 +337,7 @@ describe("Password Resets", async () => {
 
 
     it("should fail for change password with 403 if header is good, but current password is incorrect", async () => {
+        expect(successfulLoginToken).not.toBeNull();
 
         await apiEndpoint.post('/user/changePassword')
             .set('Authorization', successfulLoginToken)
@@ -446,6 +452,9 @@ describe ("Change User Details", async () => {
     });
 
     it('should return a User by uid no history', async () => {
+        expect(knownUserUid).not.toBeNull();
+        expect(loginAuthToken).not.toBeNull();
+        expect(establishmentId).not.toBeNull();
         
         const getUserResponse = await apiEndpoint.get(`/user/establishment/${establishmentId}/${encodeURIComponent(knownUserUid)}?history=none`)
             .set('Authorization', loginAuthToken)
@@ -485,7 +494,10 @@ describe ("Change User Details", async () => {
     });
 
     it('should return a User by username no history', async () => {
+        xpect(knownUserUid).not.toBeNull();
+        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
+        expect(establishmentId).not.toBeNull();
 
         const getUserResponse = await apiEndpoint.get(`/user/establishment/${establishmentId}/${encodeURIComponent(fetchUsername)}?history=none`)
             .set('Authorization', loginAuthToken)
@@ -521,7 +533,10 @@ describe ("Change User Details", async () => {
     });
 
     it('should get user with property history', async () => {
+        expect(knownUserUid).not.toBeNull();
+        expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
+        expect(establishmentId).not.toBeNull();
 
         const getUserResponse = await apiEndpoint.get(`/user/establishment/${establishmentId}/${encodeURIComponent(fetchUsername)}?history=property`)
             .set('Authorization', loginAuthToken)

--- a/test/accounts/accounts.test.js
+++ b/test/accounts/accounts.test.js
@@ -59,6 +59,7 @@ describe("Password Resets", async () => {
             .expect('Content-Type', /json/)
             .expect(200);
         expect(loginResponse.body.role).toEqual('Edit');
+
     });
 
     it("should lookup a known username via usernameOrPasswword with success", async () => {
@@ -321,7 +322,7 @@ describe("Password Resets", async () => {
     });
 
     it("should fail for change password with 400 new password is not of required complexity", async () => {
-        expect(successfulLoginToken).not.toBeNull(); 
+        expect(successfulLoginToken).not.toBeNull();
 
         // NOTE - there is no checking on history of password used
         // Intentionally not validating complexity of current password
@@ -494,7 +495,7 @@ describe ("Change User Details", async () => {
     });
 
     it('should return a User by username no history', async () => {
-        xpect(knownUserUid).not.toBeNull();
+        expect(knownUserUid).not.toBeNull();
         expect(loginAuthToken).not.toBeNull();
         const fetchUsername = nonCQCSite.user.username;
         expect(establishmentId).not.toBeNull();

--- a/test/establishments/establishment.test.js
+++ b/test/establishments/establishment.test.js
@@ -112,6 +112,7 @@ describe ("establishment", async () => {
             expect(nmdsIdRegex.test(loginResponse.body.establishment.nmdsId)).toEqual(true);
             expect(loginResponse.body.isFirstLogin).toEqual(true);
             expect(Number.isInteger(loginResponse.body.mainService.id)).toEqual(true);
+            expect(loginResponse.body.lastLoggedIn).toBeNull();
 
             // login a second time and confirm revised firstLogin status
             const secondLoginResponse = await apiEndpoint.post('/login')
@@ -121,6 +122,10 @@ describe ("establishment", async () => {
                 })
                 .expect('Content-Type', /json/)
                 .expect(200);
+
+            expect(secondLoginResponse.body.lastLoggedIn).not.toBeNull();
+            const lastLoggedInDate = new Date(secondLoginResponse.body.lastLoggedIn);
+            expect(lastLoggedInDate.toISOString()).toEqual(secondLoginResponse.body.lastLoggedIn);
             
             expect(secondLoginResponse.body.isFirstLogin).toEqual(false);
             expect(secondLoginResponse.body.establishment.name).toEqual(site.locationName);

--- a/test/reference/__snapshots__/reference.test.js.snap
+++ b/test/reference/__snapshots__/reference.test.js.snap
@@ -3152,6 +3152,115 @@ Object {
 }
 `;
 
+exports[`Expected reference services should fetch service users 1`] = `
+Object {
+  "serviceUsers": Object {
+    "Adults": Array [
+      Object {
+        "id": 10,
+        "service": "Adults with dementia",
+      },
+      Object {
+        "id": 11,
+        "service": "Adults with mental disorders or infirmities, excluding learning disability or dementia",
+      },
+      Object {
+        "id": 12,
+        "service": "Adults detained under the Mental Health Act",
+      },
+      Object {
+        "id": 13,
+        "service": "Adults with learning disabilities and/or autism",
+      },
+      Object {
+        "id": 14,
+        "service": "Adults with physical disabilities",
+      },
+      Object {
+        "id": 15,
+        "service": "Adults with sensory impairments",
+      },
+      Object {
+        "id": 16,
+        "service": "Adults who misuse alcohol/drugs",
+      },
+      Object {
+        "id": 17,
+        "service": "Adults with an eating disorder",
+      },
+      Object {
+        "id": 18,
+        "service": "Adults not in above categories",
+      },
+    ],
+    "Carers": Array [
+      Object {
+        "id": 20,
+        "service": "Carers of older people",
+      },
+      Object {
+        "id": 21,
+        "service": "Carers of adults",
+      },
+      Object {
+        "id": 22,
+        "service": "Carers of children and young people",
+      },
+    ],
+    "Children and young people": Array [
+      Object {
+        "id": 19,
+        "service": "Any children and young people",
+      },
+    ],
+    "Older people": Array [
+      Object {
+        "id": 1,
+        "service": "Older people with dementia",
+      },
+      Object {
+        "id": 2,
+        "service": "Older people with mental disorders or infirmities, excluding learning disability or dementia",
+      },
+      Object {
+        "id": 3,
+        "service": "Older people detained under the Mental Health Act",
+      },
+      Object {
+        "id": 4,
+        "service": "Older people with learning disabilities and/or autism",
+      },
+      Object {
+        "id": 5,
+        "service": "Older people with physical disabilities",
+      },
+      Object {
+        "id": 6,
+        "service": "Older people with sensory impairment(s)",
+      },
+      Object {
+        "id": 7,
+        "service": "Older people who misuse alcohol/drugs",
+      },
+      Object {
+        "id": 8,
+        "service": "Older people with an eating disorder",
+      },
+      Object {
+        "id": 9,
+        "service": "Older people not in above categories",
+      },
+    ],
+    "Other": Array [
+      Object {
+        "id": 23,
+        "service": "Any others not in above categories",
+      },
+    ],
+  },
+}
+`;
+
 exports[`Expected reference services should fetch services 1`] = `
 Array [
   Object {

--- a/test/reference/reference.test.js
+++ b/test/reference/reference.test.js
@@ -100,4 +100,11 @@ describe ("Expected reference services", async () => {
             .expect(200);
         expect(workerLeaverReasons.body).toMatchSnapshot();
     });
+
+    it("should fetch service users", async () => {
+        const serviceUsers = await apiEndpoint.get('/serviceUsers')
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(serviceUsers.body).toMatchSnapshot();
+    });
 });

--- a/test/utils/changeHistory.js
+++ b/test/utils/changeHistory.js
@@ -1,7 +1,7 @@
 let MIN_TIME_TOLERANCE = process.env.TEST_DEV ? 1000 : 400;
 let MAX_TIME_TOLERANCE = process.env.TEST_DEV ? 3000 : 1000;
 
-exports.validatePropertyChangeHistory = (name, PropertiesResponses, property, currentValue, previousValue, username, requestEpoch, compareFunction) => {
+exports.validatePropertyChangeHistory = (name, PropertiesResponses, property, currentValue, previousValue, username, requestEpoch, compareFunction, numChangeHistoryEvent=4) => {
     /* eg.
     { currentValue: [ { jobId: 7, title: 'Assessment Officer' } ],
       lastSavedBy: 'Federico.Lebsack',
@@ -38,8 +38,9 @@ exports.validatePropertyChangeHistory = (name, PropertiesResponses, property, cu
     expect(property.lastChangedBy).toEqual(username);
 
     const changeHistory = property.changeHistory;
+    //console.log("WA DEBUG change history: ", changeHistory)
     expect(Array.isArray(changeHistory)).toEqual(true);
-    expect(changeHistory.length).toEqual(4);
+    expect(changeHistory.length).toEqual(numChangeHistoryEvent);
     expect(changeHistory[0].username).toEqual(username);
     expect(changeHistory[1].username).toEqual(username);
     expect(changeHistory[2].username).toEqual(username);

--- a/test/utils/changeHistory.js
+++ b/test/utils/changeHistory.js
@@ -1,5 +1,5 @@
 let MIN_TIME_TOLERANCE = process.env.TEST_DEV ? 1000 : 400;
-let MAX_TIME_TOLERANCE = process.env.TEST_DEV ? 3000 : 1000;
+let MAX_TIME_TOLERANCE = process.env.TEST_DEV ? 3000 : 1300;
 
 exports.validatePropertyChangeHistory = (name, PropertiesResponses, property, currentValue, previousValue, username, requestEpoch, compareFunction, numChangeHistoryEvent=4) => {
     /* eg.


### PR DESCRIPTION
* Service users
* Name
* Main Service

Includes update to accounts test set to allow for previous registration refactoring which uses the managed property classes now which results in the initial saved/changed audit events.

And update to reference test to include the new set of "Service Users" lookup values.