### PR TITLE
Adding rudimentary expectations on successful login for establishment…

### DIFF
--- a/test/establishments/establishment.test.js
+++ b/test/establishments/establishment.test.js
@@ -108,6 +108,8 @@ describe ("establishment", async () => {
 
             expect(loginResponse.body.establishment.id).toEqual(establishmentId);
             expect(loginResponse.body.establishment.uid).toEqual(establishmentUid);
+            expect(loginResponse.body.establishment.isParent).toEqual(false);
+            expect(loginResponse.body.establishment).not.toHaveProperty('parentUid');
             expect(loginResponse.body.establishment.isRegulated).toEqual(false);
             expect(nmdsIdRegex.test(loginResponse.body.establishment.nmdsId)).toEqual(true);
             expect(loginResponse.body.isFirstLogin).toEqual(true);


### PR DESCRIPTION
… isParent and parentUid. Establishment registration is a standlone so expectation is known.